### PR TITLE
fix: to generate attribute 'id' and var 'platform_serial_number'

### DIFF
--- a/config/OG1_global_attrs.yaml
+++ b/config/OG1_global_attrs.yaml
@@ -2,12 +2,14 @@ attr_to_add:
   title: OceanGliders trajectory file
   platform: sub-surface gliders
   platform_vocabulary: https://vocab.nerc.ac.uk/collection/L06/current/27
+  id: null
   featureType: trajectoryProfile
   Conventions: CF-1.10,OG-1.0
   rtqc_method: No QC applied
   rtqc_method_doi: n/a
 #  doi: ''
 #  data_url: ''
+
 attr_as_is: !!set
   geospatial_lon_min: null
   institution: null
@@ -18,7 +20,6 @@ attr_as_is: !!set
   project: null
   keywords: null
   acknowledgment: null
-  id: null
   geospatial_lat_min: null
   naming_authority: null
   keywords_vocabulary: null
@@ -26,12 +27,33 @@ attr_as_is: !!set
   geospatial_lat_max: null
   date_created: null
   license: null
+
 attr_to_rename:
   site: summary
   uri: uuid
   uri_comment: UUID
   comment: history
-  id: PLATFORM_SERIAL_NUMBER
+  platform_id: PLATFORM_SERIAL_NUMBER
+
 attr_to_var:
   landstation_version: base_station_version
   glider_firmware_version: seaglider_software_version
+
+attr_mandatory:
+  title: null
+  platform: null
+  platform_vocabulary: null
+  id: null
+  contributor_name: null
+  contributor_role: null
+  contributer_email: null@null.com
+  contributor_role_vocabulary: null
+  contributing_institutions: null
+  contributing_institutions_role: null
+  contributing_institutions_role_vocabulary: null
+  rtqc_method: null
+  start_date: null
+  date_created: null
+  featureType: null
+  Conventions: null
+

--- a/config/OG1_global_attrs.yaml
+++ b/config/OG1_global_attrs.yaml
@@ -2,7 +2,6 @@ attr_to_add:
   title: OceanGliders trajectory file
   platform: sub-surface gliders
   platform_vocabulary: https://vocab.nerc.ac.uk/collection/L06/current/27
-  id: null
   featureType: trajectoryProfile
   Conventions: CF-1.10,OG-1.0
   rtqc_method: No QC applied
@@ -14,6 +13,7 @@ attr_as_is: !!set
   geospatial_lon_min: null
   institution: null
   disclaimer: null
+  id: null
   file_version: null
   geospatial_vertical_max: null
   geospatial_vertical_min: null

--- a/seagliderOG1/convertOG1.py
+++ b/seagliderOG1/convertOG1.py
@@ -46,7 +46,7 @@ def convert_to_OG1(datasets, contrib_to_append=None):
     if 'platform_id' in ds.attrs:
         PLATFORM_SERIAL_NUMBER = ds.attrs['platform_id'].lower()
     else:
-        PLATFORM_SERIAL_NUMBER = 'sg' + concatenated_ds.attrs['id']
+        PLATFORM_SERIAL_NUMBER = 'sg000' 
     concatenated_ds['PLATFORM_SERIAL_NUMBER'] = PLATFORM_SERIAL_NUMBER
     concatenated_ds['PLATFORM_SERIAL_NUMBER'].attrs['long_name'] = "glider serial number"
 

--- a/seagliderOG1/writers.py
+++ b/seagliderOG1/writers.py
@@ -22,7 +22,7 @@ def save_dataset(ds, output_file='../test.nc'):
     # More general
     valid_types = (str, Number, np.ndarray, np.number, list, tuple)
     try:
-        ds.to_netcdf(output_file, format='NETCDF4_CLASSIC')
+        ds.to_netcdf(output_file, format='NETCDF4')
         return True
     except TypeError as e:
         print(e.__class__.__name__, e)
@@ -32,7 +32,7 @@ def save_dataset(ds, output_file='../test.nc'):
                     print(f"variable '{varname}': Converting attribute '{k}' with value '{v}' to string.")
                     variable.attrs[k] = str(v)
         try:
-            ds.to_netcdf(output_file, format='NETCDF4_CLASSIC')
+            ds.to_netcdf(output_file, format='NETCDF4')
             return True
         except Exception as e:
             print("Failed to save dataset:", e)


### PR DESCRIPTION
I realised when running at seaglider OG1 netcdf file (dg042) through [glider_test](https://github.com/oceangliderscommunity/glidertest) with the new "mission_summary" functionality, that the OG1 seaglider dataset was missing a mandatory variable `PLATFORM_SERIAL_NUMBER` (e.g., 'sg015' for seaglider number 15), required in [OG1 format](https://oceangliderscommunity.github.io/OG-format-user-manual/OG_Format.html).

What seagliderOG1 was doing: it was adding a blank global attribute `id` and then trying to use this to create `PLATFORM_SERIAL_NUMBER` by appending `sg` before it.  Instead, the basestation attribute `platform_id` should be used as `PLATFORM_SERIAL_NUMBER`, and the attribute `id` (which should be e.g. `sg015_20040924t171911_delayed`) is built from the variable `PLATFOR_SERIAL_NUMBER` and the `start_date`.

- Updated to now use the existing attribute `platform_id` as the `PLATFORM_SERIAL_NUMBER`

- Additional small edit to `writers.save_dataset()` to use `format=NETCDF4` instead of `NETCDF4_CLASSIC`, which helps on some failed saves.