### PR TITLE
FEAT: Adding logging functionality

### DIFF
--- a/config/OG1_var_names.yaml
+++ b/config/OG1_var_names.yaml
@@ -22,8 +22,8 @@ temperature_raw: TEMP_RAW
 salinity_raw: PSAL_RAW
 conductivity_raw: CNDC_RAW
 salinity: PSAL
-absolute_salinity: SA
-conservative_temperature: CT
+#absolute_salinity: SA
+#conservative_temperature: CT
 ctd_density: DENSITY
 profile_index: PROFILE_NUMBER
 vert_speed: GLIDER_VERT_VELO_MODEL

--- a/config/OG1_vocab_attrs.yaml
+++ b/config/OG1_vocab_attrs.yaml
@@ -214,6 +214,8 @@ DOXY:
   valid_max: 425
   valid_min: 0
   URI: https://vocab.nerc.ac.uk/collection/P02/current/DOXY/
+TIME_DOXY:
+  long_name: time for oxygen concentration in GMT epoch format
 OXYSAT:
   long_name: Oxygen saturation by Optode
   observation_type: calculated
@@ -311,6 +313,8 @@ THETA:
   valid_max: 42
   valid_min: -5
   URI: https://vocab.nerc.ac.uk/collection/OG1/current/THETA/
+CT:
+  long_name: Conservative temperature
 POTDENS0:
   long_name: Potential density of water body at surface
   standard_name: sea_water_potential_density

--- a/notebooks/run_dataset.ipynb
+++ b/notebooks/run_dataset.ipynb
@@ -1,0 +1,161 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Run through datasets\n",
+    "\n",
+    "Run a list of datasets, generating log files and data output files in data/"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This cell imports for development work\n",
+    "import pathlib\n",
+    "import sys\n",
+    "import warnings\n",
+    "warnings.simplefilter(\"ignore\", category=Warning)\n",
+    "import logging\n",
+    "_log = logging.getLogger(__name__)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from seagliderOG1 import readers, writers, plotters, utilities, tools\n",
+    "from seagliderOG1 import convertOG1\n",
+    "from seagliderOG1 import vocabularies\n",
+    "import xarray as xr\n",
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load Seaglider data in basestation format\n",
+    "\n",
+    "Test case build on a file which was written in 2013 by basestation v2.8 into nodc format template v0.9.\n",
+    "\n",
+    "This is the same process as above (contained in `convertOG1.convert_to_OG1`), but breaking out to access the sub-functions individually.  This way you can inspect the process as it goes along, and also inspect some of the data which did not make it into the final dataset:\n",
+    "\n",
+    "- `sg_cal` - details from `sg_calib_constants.m`, \n",
+    "- `dc_log` - log events, and \n",
+    "- `dc_other` - random other variables that were in the basestation file)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/Users/eddifying/Cloudfree/gitlab-cloudfree/seagliderOG1\n",
+      "['/Users/eddifying/micromamba/envs/messfern_env/lib/python313.zip', '/Users/eddifying/micromamba/envs/messfern_env/lib/python3.13', '/Users/eddifying/micromamba/envs/messfern_env/lib/python3.13/lib-dynload', '', '/Users/eddifying/Cloudfree/gitlab-cloudfree/seagliderOG1/venv/lib/python3.13/site-packages', '/Users/eddifying/Cloudfree/gitlab-cloudfree/seagliderOG1', '/Users/eddifying/Cloudfree/gitlab-cloudfree/seagliderOG1/seagliderOG1']\n",
+      "Running the directory: https://www.ncei.noaa.gov/data/oceans/glider/seaglider/uw/033/20100729/\n",
+      "TypeError Invalid value for attr 'calibration_parameters': {'t_g': 0.00435754738, 't_h': 0.000629403181, 't_i': 2.43066775e-05, 't_j': 2.62239863e-06, 'c_g': -10.3320573, 'c_h': 1.20947434, 'c_i': -0.00161928789, 'c_j': 0.000218257457, 'cpcor': -9.57e-08, 'ctcor': 3.25e-06}. For serialization to netCDF files, its value must be of one of the following types: str, Number, ndarray, number, list, tuple, bytes\n",
+      "Running the directory: https://www.ncei.noaa.gov/data/oceans/glider/seaglider/uw/034/20110128/\n",
+      "TypeError Invalid value for attr 'calibration_parameters': {'t_g': 0.00435118603, 't_h': 0.00062670782, 't_i': 2.33362459e-05, 't_j': 2.42888781e-06, 'c_g': -10.0941847, 'c_h': 1.15925676, 'c_i': -0.00114339134, 'c_j': 0.000168957653, 'cpcor': -9.57e-08, 'ctcor': 3.25e-06}. For serialization to netCDF files, its value must be of one of the following types: str, Number, ndarray, number, list, tuple, bytes\n"
+     ]
+    }
+   ],
+   "source": [
+    "script_dir = pathlib.Path().parent.absolute()\n",
+    "parent_dir = script_dir.parents[0]\n",
+    "sys.path.append(str(parent_dir))\n",
+    "sys.path.append(str(parent_dir) + '/seagliderOG1')\n",
+    "print(parent_dir)\n",
+    "print(sys.path)\n",
+    "\n",
+    "# Specify the path for writing datafiles\n",
+    "data_path = os.path.join(parent_dir, 'data')\n",
+    "\n",
+    "input_locations = [\n",
+    "    # Either Iceland, Faroes or RAPID/MOCHA\n",
+    "    \"https://www.ncei.noaa.gov/data/oceans/glider/seaglider/uw/005/20090829/\", # done\n",
+    "    \"https://www.ncei.noaa.gov/data/oceans/glider/seaglider/uw/005/20080606/\", # done\n",
+    "    \"https://www.ncei.noaa.gov/data/oceans/glider/seaglider/uw/005/20081106/\", # done\n",
+    "    \"https://www.ncei.noaa.gov/data/oceans/glider/seaglider/uw/012/20070831/\", # done\n",
+    "    \"https://www.ncei.noaa.gov/data/oceans/glider/seaglider/uw/014/20080214/\",  # done\n",
+    "    \"https://www.ncei.noaa.gov/data/oceans/glider/seaglider/uw/014/20080222/\", # done\n",
+    "    \"https://www.ncei.noaa.gov/data/oceans/glider/seaglider/uw/016/20061112/\",  # done\n",
+    "    \"https://www.ncei.noaa.gov/data/oceans/glider/seaglider/uw/016/20090605/\", # done\n",
+    "    \"https://www.ncei.noaa.gov/data/oceans/glider/seaglider/uw/016/20071113/\", # done\n",
+    "    \"https://www.ncei.noaa.gov/data/oceans/glider/seaglider/uw/016/20080607/\",  # done\n",
+    "    \"https://www.ncei.noaa.gov/data/oceans/glider/seaglider/uw/033/20100518/\",\n",
+    "    \"https://www.ncei.noaa.gov/data/oceans/glider/seaglider/uw/033/20100903/\",\n",
+    "    \"https://www.ncei.noaa.gov/data/oceans/glider/seaglider/uw/101/20081108/\",\n",
+    "    \"https://www.ncei.noaa.gov/data/oceans/glider/seaglider/uw/101/20061112/\",\n",
+    "    \"https://www.ncei.noaa.gov/data/oceans/glider/seaglider/uw/101/20070609/\",\n",
+    "    \"https://www.ncei.noaa.gov/data/oceans/glider/seaglider/uw/102/20061112/\",\n",
+    "    # Labrador Sea\n",
+    "    \"https://www.ncei.noaa.gov/data/oceans/glider/seaglider/uw/015/20040924/\",\n",
+    "    \"https://www.ncei.noaa.gov/data/oceans/glider/seaglider/uw/014/20040924/\",\n",
+    "    \"https://www.ncei.noaa.gov/data/oceans/glider/seaglider/uw/008/20031002/\",\n",
+    "    \"https://www.ncei.noaa.gov/data/oceans/glider/seaglider/uw/004/20031002/\",\n",
+    "    \"https://www.ncei.noaa.gov/data/oceans/glider/seaglider/uw/016/20050406/\",\n",
+    "    # RAPID/MOCHA\n",
+    "    \"https://www.ncei.noaa.gov/data/oceans/glider/seaglider/uw/033/20100729/\",\n",
+    "    \"https://www.ncei.noaa.gov/data/oceans/glider/seaglider/uw/034/20110128/\",\n",
+    "    # RAPID/MOCHA\n",
+    "\n",
+    "]\n",
+    "\n",
+    "for input_loc in input_locations:\n",
+    "    sg_num = input_loc.split('/')[8]\n",
+    "    start_date = input_loc.split('/')[9]\n",
+    "    # Name the log file - note that this is specific to the input locations above!\n",
+    "    logf = 'sg'+sg_num +'_' + start_date+'.log'\n",
+    "    logf_with_path = os.path.join(data_path, logf)\n",
+    "\n",
+    "    # Set up logging\n",
+    "    logging.basicConfig(\n",
+    "        filename=logf_with_path, \n",
+    "        encoding='utf-8',\n",
+    "        format=\"%(asctime)s %(levelname)-8s %(funcName)s %(message)s\",\n",
+    "        filemode=\"w\",\n",
+    "        level=logging.INFO,\n",
+    "        datefmt=\"%Y%m%dT%H%M%S\",\n",
+    "        force=True,\n",
+    "        )\n",
+    "    _log.info('convertOG1.process_and_save_data')\n",
+    "    _log.info('Processing data from: %s', input_loc)\n",
+    "    # Example usage\n",
+    "    ds_all = convertOG1.process_and_save_data(input_loc, output_dir=data_path, save=True,  run_quietly=True)\n",
+    "    _log.info('Finished processing data from: %s', input_loc)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/seagliderOG1/readers.py
+++ b/seagliderOG1/readers.py
@@ -32,7 +32,7 @@ data_source_og = pooch.create(
 registry_file = files('seagliderOG1').joinpath('seaglider_registry.txt')
 data_source_og.load_registry(registry_file)
 
-def load_sample_dataset(dataset_name="p0040034_20031007.nc"):
+def load_sample_dataset(dataset_name="p0150500_20050213.nc"):
     if dataset_name in data_source_og.registry.keys():
         file_path = data_source_og.fetch(dataset_name)
         return xr.open_dataset(file_path)
@@ -56,7 +56,9 @@ def filter_files_by_profile(file_list, start_profile=None, end_profile=None):
 
     for file in file_list:
         if file.endswith(".nc"):
-            profile_number = int(file.split("_")[0][4:])
+            # Extract the profile number from the filename now from the begining
+            #profile_number = int(file.split("_")[0][4:])
+            profile_number = int(file[5:8])
             if start_profile is not None and end_profile is not None:
                 if start_profile <= profile_number <= end_profile:
                     filtered_files.append(file)

--- a/seagliderOG1/utilities.py
+++ b/seagliderOG1/utilities.py
@@ -33,19 +33,19 @@ def _validate_coords(ds1):
     id = ds1.attrs['id']
     if 'longitude' not in ds1.coords:
         ds1 = ds1.assign_coords(longitude=("sg_data_point", [float('nan')] * ds1.dims['sg_data_point']))
-        print(f'{id}: No coord longitude - adding as NaNs to length of sg_data_point')
+        _log.warning(f"{id}: No coord longitude - adding as NaNs to length of sg_data_point")
     if 'latitude' not in ds1.coords:
         ds1 = ds1.assign_coords(latitude=("sg_data_point", [float('nan')] * ds1.dims['sg_data_point']))
-        print(f'{id}: No coord latitude - adding as NaNs to length of sg_data_point')
+        _log.warning(f"{id}: No coord latitude - adding as NaNs to length of sg_data_point")
     if 'ctd_time' in ds1.variables:
         if 'ctd_time' not in ds1.coords:
             ds1 = ds1.assign_coords(ctd_time=("sg_data_point", ds1['ctd_time'].values))
-            print(f'{id}: No coord ctd_time, but exists as variable - assigning coord from variable')
+            _log.warning(f"{id}: No coord ctd_time, but exists as variable - assigning coord from variable")    
         if 'ctd_depth' not in ds1.coords:
             ds1 = ds1.assign_coords(ctd_depth=("sg_data_point", ds1['ctd_depth'].values))
-            print(f'{id}: No coord ctd_depth, but exists as variable - assigning coord from variable')
+            _log.warning(f"{id}: No coord ctd_depth, but exists as variable - assigning coord from variable")
     else:
-        print(f'{id}: !!! No variable ctd_time - returning an empty dataset')
+        _log.warning(f"{id}: No variable ctd_time - returning an empty dataset")
 
         ds1 = xr.Dataset()
     return ds1
@@ -57,15 +57,27 @@ def _validate_dims(ds):
         raise ValueError(f"Dimension name '{dim_name}' is not 'N_MEASUREMENTS'.")
     
 
-def _parse_calibcomm(calibcomm):
+def _parse_calibcomm(calibcomm, firstrun=False):
     if 'calibration' in calibcomm.values.item().decode('utf-8'):
 
         cal_date = calibcomm.values.item().decode('utf-8')
-        print(cal_date)
+        if firstrun:
+            _log.info(f"sg_cal_calibcomm: {cal_date}")
         cal_date = cal_date.split('calibration')[-1].strip()
         cal_date = cal_date.replace(' ', '')
-        print(cal_date)
-        cal_date_YYYYmmDD = datetime.datetime.strptime(cal_date, '%d%b%y').strftime('%Y%m%d')
+        if firstrun:
+            _log.info(f"cal_date: {cal_date}")
+        # Different date formats in calibration comments
+        formats = ['%d%b%y', '%d-%b-%y']
+        cal_date_YYYYmmDD = None
+        for fmt in formats:
+            try:
+            # Try to parse the date with the current format
+                cal_date_YYYYmmDD = datetime.datetime.strptime(cal_date, fmt).strftime('%Y%m%d')
+                break  # Exit the loop if parsing is successful
+            except ValueError:
+                continue  # Try the next format if parsing fails
+        #cal_date_YYYYmmDD = datetime.datetime.strptime(cal_date, '%d%b%y').strftime('%Y%m%d')
     else:   
         cal_date_YYYYmmDD = 'Unknown'
     if 's/n' in calibcomm.values.item().decode('utf-8'):
@@ -73,9 +85,14 @@ def _parse_calibcomm(calibcomm):
         serial_number = serial_match.group(0).replace('s/n  ', '').strip()
     else:
         serial_number = 'Unknown'
-    print(serial_number)
+    serial_number = serial_number.replace('s/n', '').strip()
+    if firstrun:
+        _log.info(f"serial number: {serial_number}")
 
     return cal_date_YYYYmmDD, serial_number
+
+def _clean_time_string(time_str):
+    return time_str.replace('_', '').replace(':', '').rstrip('Z').replace('-', '')
 
 def _clean_anc_vars_list(ancillary_variables_str):
     ancillary_variables_str = re.sub(r"(\w)(sg_cal)", r"\1 \2", ancillary_variables_str)
@@ -86,6 +103,10 @@ def _clean_anc_vars_list(ancillary_variables_str):
 def _assign_calval(sg_cal, anc_var_list):
     calval = {}
     for anc_var in anc_var_list:
-        var_value = sg_cal[anc_var].values.item()
-        calval[anc_var] = var_value
+        # Check if anc_var exists in sg_cal which was not the case in Robs dataset
+        if anc_var in sg_cal:  
+            var_value = sg_cal[anc_var].values.item()
+            calval[anc_var] = var_value
+        else:
+            calval[anc_var] = 'Unknown'
     return calval

--- a/seagliderOG1/writers.py
+++ b/seagliderOG1/writers.py
@@ -1,6 +1,9 @@
 import numpy as np
 import xarray as xr
 from numbers import Number
+import logging
+
+_log = logging.getLogger(__name__)
 
 def save_dataset(ds, output_file='../test.nc'):
     """
@@ -26,18 +29,23 @@ def save_dataset(ds, output_file='../test.nc'):
         return True
     except TypeError as e:
         print(e.__class__.__name__, e)
+        _log.error(f"{e.__class__.__name__}")
+        _log.error(f"{e}")
         for varname, variable in ds.variables.items():
             for k, v in variable.attrs.items():
                 if not isinstance(v, valid_types) or isinstance(v, bool):
-                    print(f"variable '{varname}': Converting attribute '{k}' with value '{v}' to string.")
+                    _log.warning(f"For variable '{varname}': Converting attribute '{k}' with value '{v}' to string.")
                     variable.attrs[k] = str(v)
         try:
             ds.to_netcdf(output_file, format='NETCDF4')
             return True
         except Exception as e:
             print("Failed to save dataset:", e)
+            _log.error(f"Failed to save dataset: {e}")
             datetime_vars = [var for var in ds.variables if ds[var].dtype == 'datetime64[ns]']
             print("Variables with dtype datetime64[ns]:", datetime_vars)
+            _log.warning(f"Variables with dtype datetime64[ns]: {datetime_vars}")
             float_attrs = [attr for attr in ds.attrs if isinstance(ds.attrs[attr], float)]
             print("Attributes with dtype float64:", float_attrs)
+            _log.warning(f"Attributes with dtype float64: {float_attrs}")
             return False


### PR DESCRIPTION
Added capability to generate a log file when converting a seaglider mission to OG1 format.

Names the log files based on the seaglider mission, e.g., `sg04_20040209.log` corresponding to `sg004_20040209T224836_delayed.nc`.

Includes time stamps when things were run, and info, warning and error messages.