### PR TITLE
FEAT: Add sensors + calcoef for oxygen

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,15 @@ jobs:
         init-shell: bash
         create-args: >-
           python=${{ matrix.python-version }} --file requirements-dev.txt --channel conda-forge
+      env:
+        MAMBA_NO_BANNER: true
+        
+    - name: Check Package Installation
+      run: |
+        micromamba env list
+        micromamba list
+        python -m pip check
+      
 
     - name: Install seagliderOG1
       run: |

--- a/config/OG1_sensor_attrs.yaml
+++ b/config/OG1_sensor_attrs.yaml
@@ -96,11 +96,27 @@ Seabird Deep SUNA:
   sensor_type: nutrient analysers
   sensor_type_vocabulary: https://vocab.nerc.ac.uk/collection/L05/current/181/
 Seabird SBE43F:
-  long_name: Sea-Bird SBE 43F
+  long_name: Sea-Bird SBE 43F 
   sensor_maker: Sea-Bird Scientific
   sensor_maker_vocabulary: http://vocab.nerc.ac.uk/collection/L35/current/MAN0013/
   sensor_model: Sea-Bird SBE 43F Dissolved Oxygen Sensor
   sensor_model_vocabulary: https://vocab.nerc.ac.uk/collection/L22/current/TOOL0037/
+  sensor_type: dissolved gas sensors
+  sensor_type_vocabulary: https://vocab.nerc.ac.uk/collection/L05/current/351/
+Aanderaa 4330:
+  long_name: Aanderaa 4330 oxygen optode
+  sensor_maker: Aanderaa
+  sensor_maker_vocabulary: https://vocab.nerc.ac.uk/collection/L35/current/MAN0007/
+  sensor_model: Aanderaa 4330 oxygen optode
+  sensor_model_vocabulary: https://vocab.nerc.ac.uk/collection/L22/current/TOOL1247
+  sensor_type: dissolved gas sensors
+  sensor_type_vocabulary: https://vocab.nerc.ac.uk/collection/L05/current/351/
+Aanderaa 4831:
+  long_name: Aanderaa 4831F oxygen optode
+  sensor_maker: Aanderaa
+  sensor_maker_vocabulary: https://vocab.nerc.ac.uk/collection/L35/current/MAN0007/
+  sensor_model: Aanderaa 4831F oxygen optode
+  sensor_model_vocabulary: https://vocab.nerc.ac.uk/collection/L22/current/TOOL1240/
   sensor_type: dissolved gas sensors
   sensor_type_vocabulary: https://vocab.nerc.ac.uk/collection/L05/current/351/
 Seabird SlocumCTD:

--- a/config/OG1_var_names.yaml
+++ b/config/OG1_var_names.yaml
@@ -12,6 +12,8 @@ pressure: PRES
 conductivity: CNDC
 aanderaa4330_dissolved_oxygen: DOXY 
 aanderaa4330_results_time: TIME_DOXY
+sbe43_dissolved_oxygen: DOXY
+sbe43_results_time: TIME_DOXY
 dissolved_oxygen_sat: OXYSAT
 oxygen_concentration: DOXY
 chlorophyll: CHLA

--- a/seagliderOG1/utilities.py
+++ b/seagliderOG1/utilities.py
@@ -58,36 +58,38 @@ def _validate_dims(ds):
     
 
 def _parse_calibcomm(calibcomm, firstrun=False):
-    if 'calibration' in calibcomm.values.item().decode('utf-8'):
+    calstr = calibcomm.values.item().decode('utf-8')
 
-        cal_date = calibcomm.values.item().decode('utf-8')
-        if firstrun:
-            _log.info(f"sg_cal_calibcomm: {cal_date}")
-        cal_date = cal_date.split('calibration')[-1].strip()
-        cal_date = cal_date.replace(' ', '')
-        if firstrun:
-            _log.info(f"cal_date: {cal_date}")
-        # Different date formats in calibration comments
-        formats = ['%d%b%y', '%d-%b-%y']
-        cal_date_YYYYmmDD = None
-        for fmt in formats:
-            try:
-            # Try to parse the date with the current format
-                cal_date_YYYYmmDD = datetime.datetime.strptime(cal_date, fmt).strftime('%Y%m%d')
-                break  # Exit the loop if parsing is successful
-            except ValueError:
-                continue  # Try the next format if parsing fails
-        #cal_date_YYYYmmDD = datetime.datetime.strptime(cal_date, '%d%b%y').strftime('%Y%m%d')
-    else:   
-        cal_date_YYYYmmDD = 'Unknown'
-    if 's/n' in calibcomm.values.item().decode('utf-8'):
-        serial_match = re.search(r's/n\s*(\d+)', calibcomm.values.item().decode('utf-8'))
-        serial_number = serial_match.group(0).replace('s/n  ', '').strip()
-    else:
-        serial_number = 'Unknown'
-    serial_number = serial_number.replace('s/n', '').strip()
+    # Parse for calibration date
+    cal_date = calstr
+    cal_date_before_keyword = cal_date
+    cal_date_YYYYmmDD = 'Unknown'
+    formats = ['%d%b%y', '%d-%b-%y', '%d/%b/%y', '%b/%d/%y', '%b-%d-%y', '%b%d%y']
+    for keyword in ['calibration', 'calibrated']:
+        if keyword in cal_date:
+            cal_date_before_keyword = cal_date.split(keyword)[0].strip()
+            cal_date = cal_date.split(keyword)[-1].strip()
+            cal_date = cal_date.replace(' ', '')
+            for fmt in formats:
+                try:
+                    cal_date_YYYYmmDD = datetime.datetime.strptime(cal_date, fmt).strftime('%Y%m%d')
+                    break  # Exit the loop if parsing is successful
+                except ValueError:
+                    continue  # Try the next format if parsing fails
+            break  # Exit the outer loop if keyword is found
+
     if firstrun:
-        _log.info(f"serial number: {serial_number}")
+        _log.info(f"     --> produces {cal_date_YYYYmmDD}")
+
+    # Parse for serial number of sensor
+    serial_number = 'unknown'
+    for keyword in ['s/n', 'S/N', 'SN', 'SBE#', 'SBE']:
+        if keyword in cal_date_before_keyword:
+            serial_match = cal_date_before_keyword.split(keyword)[-1].strip()
+            serial_number = serial_match.replace(keyword, '').strip()
+            break # Exit the outer loop if keyword is found
+    if firstrun:
+        _log.info(f"     --> produces serial_number {serial_number}")
 
     return cal_date_YYYYmmDD, serial_number
 

--- a/seagliderOG1/utilities.py
+++ b/seagliderOG1/utilities.py
@@ -87,6 +87,7 @@ def _parse_calibcomm(calibcomm, firstrun=False):
         if keyword in cal_date_before_keyword:
             serial_match = cal_date_before_keyword.split(keyword)[-1].strip()
             serial_number = serial_match.replace(keyword, '').strip()
+            serial_number = serial_number.replace('/','').strip()
             break # Exit the outer loop if keyword is found
     if firstrun:
         _log.info(f"     --> produces serial_number {serial_number}")

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,0 +1,52 @@
+import pathlib
+import sys
+
+script_dir = pathlib.Path(__file__).parent.absolute()
+parent_dir = script_dir.parents[0]
+sys.path.append(str(parent_dir))
+
+from seagliderOG1 import utilities
+
+
+def calibcomm():
+    """
+    Test function for the `utilities._parse_calibcomm` function.
+    This function defines a set of test strings with expected calibration dates and serial numbers.
+    It then iterates over these test strings, parses them using the `_parse_calibcomm` function,
+    and asserts that the parsed results match the expected values.
+    Test strings and their expected results:
+        - "SBE s/n 0112 calibration 20apr09": ('20090420', '0112')
+        - "SBE#29613t1/c1 calibration 7 Sep 02": ('20020907', '29613')
+        - "SBE t12/c12 calibration 30DEC03": ('20031230', 'Unknown')
+        - "SBE s/n 19, calibration 9/10/08": ('20080910', '19')
+        - "SBE 0015 calibration 4/28/08": ('20080428', '0015')
+        - "SBE 24520-1 calibration 04FEB08": ('20080204', '24520-1')
+        - "SBE 0021 calibration 15sep08": ('20080915', '0021')
+        - "SBE s/n 0025, calibration 10 june 08": ('20080610', '0025')
+    Asserts:
+        - The parsed calibration date matches the expected calibration date.
+        - The parsed serial number matches the expected serial number.
+    """
+    
+    test_strings = {"SBE s/n 0112 calibration 20apr09": ('20090420', '0112'),
+        "SBE#29613t1/c1 calibration 7 Sep 02": ('20020907', '29613t1c1'),
+        "SBE t12/c12 calibration 30DEC03": ('20031230', 't12c12'),
+        "SBE s/n 19, calibration 9/10/08": ('20080910', '19'),
+        "SBE 0015 calibration 4/28/08": ('20080428', '0015'),
+        "SBE 24520-1 calibration 04FEB08": ('20080204', '24520'),
+        "SBE 0021 calibration 15sep08": ('20080915', '0021'),
+        "SBE s/n 0025, calibration 10 june 08": ('20080610', '0025'),
+        "Optode 4330F S/N 182 foil batch 2808F calibrated 09may09": ('20090509', '182'),
+        "SBE 43F s/n 25281-1 calibration 12 Aug 01": ('20010812', '25281'),
+        "SBE 43F s/n 041 calibration 22JAN04": ('20040122', '041'),
+        "SBE 43 s/n F0012 calibration 27 Aug 02": ('20020827', 'F0012'), 
+        "0061": ('Unknown', '0061'),
+        "SBE 43F s/n 029 calibration 07May07": ('20070507', '029'),
+    }
+
+    for calstring, (caldate1, serialnum1) in test_strings.items():
+        caldate, serialnum = utilities._parse_calibcomm(calstring, firstrun=False)
+
+        assert caldate == caldate1
+        assert serialnum == serialnum1
+


### PR DESCRIPTION
Add oxygen sensors Aanderaa 4330 and SBE43, addresses issue #14 

- Added sensors to `OG1_sensor_attrs.yaml` for oxygen optodes.
- Improved parsing of the calibration information, present as `calibcomm` (was sg_cal_calibcomm) for CTD info, and `calibcomm_oxygen` or `calibcomm_optode` for oxygen.  Can handle more types of strings, but note there is some uncertainty in parsing of calibration dates due to inconsistent formatting.
- Added instrument type 'sbe43' and 'aa4330'.  These have a range of ancillary variables mostly along the lines of `optode_*Coef*`.  