### PR TITLE
breaking: Renamed functions in readers, added test_readers

### DIFF
--- a/notebooks/run_dataset.ipynb
+++ b/notebooks/run_dataset.ipynb
@@ -4,9 +4,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Run through datasets\n",
+    "# Convert an entire seaglider mission\n",
     "\n",
-    "Run a list of datasets, generating log files and data output files in data/"
+    "Given an online location or folder on your computer, process a full mission of basestation netCDF files into a single seagliderOG1 mission file.  \n",
+    "\n",
+    "- Provide the input location (directory of `p*.nc` files) and output location (where the netCDF file and log file will be saved)\n",
+    "- Optional: Provide details of contributing authors (e.g., who created the OG1 format file) to be appended to the output file's attributes"
    ]
   },
   {
@@ -19,9 +22,7 @@
     "import pathlib\n",
     "import sys\n",
     "import warnings\n",
-    "warnings.simplefilter(\"ignore\", category=Warning)\n",
-    "import logging\n",
-    "_log = logging.getLogger(__name__)\n"
+    "warnings.simplefilter(\"ignore\", category=Warning)"
    ]
   },
   {
@@ -34,39 +35,29 @@
     "from seagliderOG1 import convertOG1\n",
     "from seagliderOG1 import vocabularies\n",
     "import xarray as xr\n",
-    "import os"
+    "import os\n",
+    "import datetime\n",
+    "import logging\n",
+    "_log = logging.getLogger(__name__)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Load Seaglider data in basestation format\n",
-    "\n",
-    "Test case build on a file which was written in 2013 by basestation v2.8 into nodc format template v0.9.\n",
-    "\n",
-    "This is the same process as above (contained in `convertOG1.convert_to_OG1`), but breaking out to access the sub-functions individually.  This way you can inspect the process as it goes along, and also inspect some of the data which did not make it into the final dataset:\n",
-    "\n",
-    "- `sg_cal` - details from `sg_calib_constants.m`, \n",
-    "- `dc_log` - log events, and \n",
-    "- `dc_other` - random other variables that were in the basestation file)."
+    "## Specify paths for inputs/outputs"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/Users/eddifying/Cloudfree/gitlab-cloudfree/seagliderOG1\n",
-      "['/Users/eddifying/micromamba/envs/messfern_env/lib/python313.zip', '/Users/eddifying/micromamba/envs/messfern_env/lib/python3.13', '/Users/eddifying/micromamba/envs/messfern_env/lib/python3.13/lib-dynload', '', '/Users/eddifying/Cloudfree/gitlab-cloudfree/seagliderOG1/venv/lib/python3.13/site-packages', '/Users/eddifying/Cloudfree/gitlab-cloudfree/seagliderOG1', '/Users/eddifying/Cloudfree/gitlab-cloudfree/seagliderOG1/seagliderOG1']\n",
-      "Running the directory: https://www.ncei.noaa.gov/data/oceans/glider/seaglider/uw/033/20100729/\n",
-      "TypeError Invalid value for attr 'calibration_parameters': {'t_g': 0.00435754738, 't_h': 0.000629403181, 't_i': 2.43066775e-05, 't_j': 2.62239863e-06, 'c_g': -10.3320573, 'c_h': 1.20947434, 'c_i': -0.00161928789, 'c_j': 0.000218257457, 'cpcor': -9.57e-08, 'ctcor': 3.25e-06}. For serialization to netCDF files, its value must be of one of the following types: str, Number, ndarray, number, list, tuple, bytes\n",
-      "Running the directory: https://www.ncei.noaa.gov/data/oceans/glider/seaglider/uw/034/20110128/\n",
-      "TypeError Invalid value for attr 'calibration_parameters': {'t_g': 0.00435118603, 't_h': 0.00062670782, 't_i': 2.33362459e-05, 't_j': 2.42888781e-06, 'c_g': -10.0941847, 'c_h': 1.15925676, 'c_i': -0.00114339134, 'c_j': 0.000168957653, 'cpcor': -9.57e-08, 'ctcor': 3.25e-06}. For serialization to netCDF files, its value must be of one of the following types: str, Number, ndarray, number, list, tuple, bytes\n"
+      "/Users/eddifying/Cloudfree/gitlab-cloudfree/seagliderOG1\n"
      ]
     }
    ],
@@ -76,11 +67,12 @@
     "sys.path.append(str(parent_dir))\n",
     "sys.path.append(str(parent_dir) + '/seagliderOG1')\n",
     "print(parent_dir)\n",
-    "print(sys.path)\n",
     "\n",
     "# Specify the path for writing datafiles\n",
     "data_path = os.path.join(parent_dir, 'data')\n",
     "\n",
+    "\n",
+    "# Provide a list of input locations\n",
     "input_locations = [\n",
     "    # Either Iceland, Faroes or RAPID/MOCHA\n",
     "    \"https://www.ncei.noaa.gov/data/oceans/glider/seaglider/uw/005/20090829/\", # done\n",
@@ -109,32 +101,70 @@
     "    \"https://www.ncei.noaa.gov/data/oceans/glider/seaglider/uw/033/20100729/\",\n",
     "    \"https://www.ncei.noaa.gov/data/oceans/glider/seaglider/uw/034/20110128/\",\n",
     "    # RAPID/MOCHA\n",
+    "    \"/Users/eddifying/Nextcloud/Shared/data-shared/data-whittard-seaglider/dg042_whittard_data\"\n",
     "\n",
     "]\n",
     "\n",
+    "input_locations = [\n",
+    "    \"https://www.ncei.noaa.gov/data/oceans/glider/seaglider/uw/033/20100903/\",\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "AttributeError",
+     "evalue": "module 'seagliderOG1.readers' has no attribute 'read_first_basestation'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[4], line 2\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m input_loc \u001b[38;5;129;01min\u001b[39;00m input_locations:\n\u001b[0;32m----> 2\u001b[0m     ds1 \u001b[38;5;241m=\u001b[39m \u001b[43mreaders\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mread_first_basestation\u001b[49m(input_loc)\n\u001b[1;32m      4\u001b[0m     \u001b[38;5;66;03m# Create a log file based on the first data file\u001b[39;00m\n\u001b[1;32m      5\u001b[0m     platform_id \u001b[38;5;241m=\u001b[39m ds1\u001b[38;5;241m.\u001b[39mattrs[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mplatform_id\u001b[39m\u001b[38;5;124m'\u001b[39m]\n",
+      "\u001b[0;31mAttributeError\u001b[0m: module 'seagliderOG1.readers' has no attribute 'read_first_basestation'"
+     ]
+    }
+   ],
+   "source": [
     "for input_loc in input_locations:\n",
-    "    sg_num = input_loc.split('/')[8]\n",
-    "    start_date = input_loc.split('/')[9]\n",
-    "    # Name the log file - note that this is specific to the input locations above!\n",
-    "    logf = 'sg'+sg_num +'_' + start_date+'.log'\n",
-    "    logf_with_path = os.path.join(data_path, logf)\n",
+    "    ds1_base = readers.load_first_basestation_file(input_loc)\n",
     "\n",
-    "    # Set up logging\n",
+    "    # Create a log file based on the first data file\n",
+    "    platform_id = ds1_base.attrs['platform_id']\n",
+    "    dive_start = ds1_base.attrs['time_coverage_start']\n",
+    "    start_time = datetime.datetime.strptime(dive_start, '%Y-%m-%dT%H:%M:%SZ').strftime('%Y%m%dT%H%M%S')\n",
+    "\n",
+    "    log_file = os.path.join(data_path, f\"{platform_id}_{start_time}.log\")\n",
+    "    logf_with_path = os.path.join(data_path, log_file)\n",
+    "\n",
+    "    # Create the log file\n",
+    "    # Note that the use of `force=True` generates a new log file each instance in the loop\n",
     "    logging.basicConfig(\n",
     "        filename=logf_with_path, \n",
     "        encoding='utf-8',\n",
     "        format=\"%(asctime)s %(levelname)-8s %(funcName)s %(message)s\",\n",
-    "        filemode=\"w\",\n",
+    "        filemode=\"w\", # 'w' to overwrite, 'a' to append\n",
     "        level=logging.INFO,\n",
     "        datefmt=\"%Y%m%dT%H%M%S\",\n",
     "        force=True,\n",
     "        )\n",
     "    _log.info('convertOG1.process_and_save_data')\n",
     "    _log.info('Processing data from: %s', input_loc)\n",
-    "    # Example usage\n",
+    "\n",
+    "    # Process the data\n",
     "    ds_all = convertOG1.process_and_save_data(input_loc, output_dir=data_path, save=True,  run_quietly=True)\n",
+    "\n",
     "    _log.info('Finished processing data from: %s', input_loc)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/seagliderOG1/convertOG1.py
+++ b/seagliderOG1/convertOG1.py
@@ -690,11 +690,11 @@ def process_and_save_data(input_location, save=False, output_dir='../data', run_
     """
 
     # Load and concatenate all datasets from the server
-    list_datasets = readers.read_basestation(input_location)
+    ds1_base = readers.load_first_basestation_file(input_location)
     
     # Convert the list of datasets to OG1
-    ds1, varlist = convert_to_OG1(list_datasets[0])
-    output_file = os.path.join(output_dir, ds1.attrs['id'] + '.nc')
+    ds1_og1, varlist = convert_to_OG1(ds1_base)
+    output_file = os.path.join(output_dir, ds1_og1.attrs['id'] + '.nc')
 
     # Check if the file exists and delete it if it does
     if os.path.exists(output_file):
@@ -716,6 +716,7 @@ def process_and_save_data(input_location, save=False, output_dir='../data', run_
     else:
         print('Running the directory:', input_location)
         _log.info(f"Running the directory: {input_location}")
+        list_datasets = readers.load_basestation_files(input_location)
         ds_all, varlist = convert_to_OG1(list_datasets)
         output_file = os.path.join(output_dir, ds_all.attrs['id'] + '.nc')
         if save:

--- a/seagliderOG1/readers.py
+++ b/seagliderOG1/readers.py
@@ -6,41 +6,59 @@ import numpy as np
 from importlib_resources import files
 import pooch
 import re
-
 # readers.py: Will only read files.  Not manipulate them.
-#
-# Comment 2024 Oct 30: I needed an initial file list to create the registry
-# This is impractical for expansion, so may need to move away from pooch.
-# This was necessary to get an initial file list
-# mylist = fetchers.list_files_in_https_server(server)
-# fetchers.create_pooch_registry_from_directory("/Users/eddifying/Dropbox/data/sg015-ncei-download/")
-# Example usage
-#directory_path = "/Users/eddifying/Dropbox/data/sg015-ncei-snippet"
-#pooch_registry = create_pooch_registry_from_directory(directory_path)
-#print(pooch_registry)
+
+# Use pooch for sample files only.
+# For the full dataset, just use BeautifulSoup / requests
+server = "https://www.ncei.noaa.gov/data/oceans/glider/seaglider/uw/033/20100903/"
+data_source_og = pooch.create(
+    path=pooch.os_cache("seagliderOG1"),
+    base_url=server,
+    registry={
+        "p0330001_20100903.nc": "1ee726a4890b5567653fd53501da8887d947946ad63a17df4e5efd2e578fb464",
+        "p0330002_20100903.nc": "1c0d6f46904063dbb1e74196bc30bdaf6163e7fbd4cc31c6087eb295688a2cc1",
+        "p0330003_20100903.nc": "779bdfb4237b17b1de8ccb5d67ef37ea28b595d918b3a034606e8612615058c3",
+        "p0330004_20100904.nc": "f981d482e04bbe5085e2f93d686eedf3a30ca125bd94696648d04b2e37fa2489",
+        "p0330005_20100904.nc": "46e921c06b407a458dd4f788b9887ea4b6a51376021190c89e0402b25b0c8f3f",
+        "p0330006_20100904.nc": "3ed79ee0757b573f32c7d72ff818b82d9810ebbd640d8a9b0f6829ab1da3b972",
+        "p0330007_20100905.nc": "29d83c65ef4649bbc9193bb25eab7a137f92da04912eae21d9fc9860e827281d",
+        "p0330008_20100905.nc": "66fa25efb8717275e84f326f3c7bd02251db7763758683c60afc4fb2e3cbb170",
+        "p0330009_20100905.nc": "ee5ce7881c74de9d765ae46c6baed4745b0620dd57f7cd7f8b9f1c7f46570836",
+        "p0330010_20100905.nc": "fad0d9bb08fc874ffacf8ed1ae25522d48ff9ff8c8f1db82bcaf4e613d6c46e3",
+        "p0330011_20100905.nc": "3b3ae89c653651e10b7a8058536d276aae9958e7d4236a4164e05707ef5a8660",
+        "p0330012_20100905.nc": "b6318d496ccddd14ede295613a2b4854f0d228c8db996737b5187e73ed226d2a",
+        "p0330013_20100906.nc": "efeb37be650368470a6fd7a9cf0cc0b6938ee9eb96b10bde166ef86cda9b6082",
+        "p0330014_20100906.nc": "6ab8bea8bc28a1d270de2da3e4cafe9aff4a01a887ebbf7d39bde5980cf585f5",
+        "p0330015_20100906.nc": "d22c2bf453601d33e51dc7f3aeecb823fefb532d44b07d45240f5400bc12b464",
+        "p0330016_20100906.nc": "404a22da318909c42dcb65fd7315ae1f5542ed8b057faa30c7b21e07f50d67a9",
+        "p0330017_20100906.nc": "06df146adee75439cc4f42e27038bec5596705fbe0a93ea53d2d65d94d719504",
+        "p0330018_20100906.nc": "3dc2363797adce65c286c5099f0144bb0583b368c84dc24185caba0cad9478a7",
+        "p0330019_20100906.nc": "7e37ad465f720ea1f1257830a595677f6d5f85d7391e711d6164ccee8ada5399"
+    }
+)
 
 # Information on creating a registry file: https://www.fatiando.org/pooch/latest/registry-files.html
 # But instead of pkg_resources (https://setuptools.pypa.io/en/latest/pkg_resources.html#)
 # we should use importlib.resources
 # Here's how to use importlib.resources (https://importlib-resources.readthedocs.io/en/latest/using.html)
-server = "https://www.dropbox.com/scl/fo/dhinr4hvpk05zcecqyz2x/ADTqIuEpWHCxeZDspCiTN68?rlkey=bt9qheandzbucca5zhf5v9j7a&dl=0"
-server = "https://www.ncei.noaa.gov/data/oceans/glider/seaglider/uw/015/20040924/"
-data_source_og = pooch.create(
-    path=pooch.os_cache("seagliderOG1"),
-    base_url=server,
-    registry=None,
-)
-registry_file = files('seagliderOG1').joinpath('seaglider_registry.txt')
-data_source_og.load_registry(registry_file)
+def load_sample_dataset(dataset_name="p0330015_20100906.nc"):
+    """Download sample datasets for use with seagliderOG1
 
+    Args:
+        dataset_name (str, optional): _description_. Defaults to "p0330015_20100906.nc".
 
-def load_sample_dataset(dataset_name="p0150500_20050213.nc"):
+    Raises:
+        ValueError: If the requests dataset is not known, raises a value error
+
+    Returns:
+        xarray.Dataset: Requested sample dataset
+    """
     if dataset_name in data_source_og.registry.keys():
         file_path = data_source_og.fetch(dataset_name)
         return xr.open_dataset(file_path)
     else:
-        msg = f"Requested sample dataset {dataset_name} not known"
-        raise ValueError(msg)
+        msg = f"Requested sample dataset {dataset_name} not known. Specify one of the following available datasets: {list(data_source_og.registry.keys())}"
+        raise KeyError(msg)
 
 def _validate_filename(filename):
     """
@@ -186,16 +204,7 @@ def list_files(source, registry_loc="seagliderOG1", registry_name="seaglider_reg
     """
 
     if source.startswith("http://") or source.startswith("https://"):
-        # Create a Pooch object to manage the remote files
-        data_source_online = pooch.create(
-            path=pooch.os_cache(registry_loc),
-            base_url=source,
-            registry=None,
-        )
-        registry_file = files(registry_loc).joinpath(registry_name)
-        data_source_og.load_registry(registry_file)
-
-        # List all files in the URL directory
+       # List all files in the URL directory
         response = requests.get(source)
         response.raise_for_status()  # Raise an error for bad status codes
 
@@ -217,24 +226,4 @@ def list_files(source, registry_loc="seagliderOG1", registry_name="seaglider_reg
 
     return file_list
 
-def create_pooch_registry_from_directory(directory):
-    """
-    Create a Pooch registry from files in a specified directory.
-
-    Parameters:
-    directory (str): The path to the directory containing the files.
-
-    Returns:
-    dict: A dictionary representing the Pooch registry with filenames as keys and their SHA256 hashes as values.
-    """
-    registry = {}
-    files = os.listdir(directory)
-
-    for file in files:
-        if file.endswith(".nc"):
-            file_path = os.path.join(directory, file)
-            sha256_hash = pooch.file_hash(file_path, alg="sha256")
-            registry[file] = f"sha256:{sha256_hash}"
-
-    return registry
 

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -9,7 +9,7 @@ from seagliderOG1 import readers
 
 
 def test_demo_datasets():
-    ds = readers.load_sample_dataset(dataset_name="p0150500_20050213.nc")
+    ds = readers.load_sample_dataset(dataset_name="p0330001_20100903.nc")
     assert ds is not None
 
 
@@ -60,7 +60,7 @@ def test_validate_filename():
         assert readers._validate_filename(filename) is False, f"Expected False for {filename}"
 
 
-def test_filter_files_by_profile():
+def test_filter_filelist_by_profile():
     """
     Test the filter_files_by_profile function from the readers module.
     This test checks the filtering of filenames based on the start_profile and

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -9,5 +9,116 @@ from seagliderOG1 import readers
 
 
 def test_demo_datasets():
-#    for remote_ds_name in readers.data_source_og.registry.keys():
     ds = readers.load_sample_dataset(dataset_name="p0150500_20050213.nc")
+    assert ds is not None
+
+
+def test_validate_filename():
+    """
+    Test the _validate_filename function from the readers module.
+    This test checks the validation of filenames to ensure they meet the expected
+    criteria. It uses a list of valid filenames that should pass the validation
+    and a list of invalid filenames that should fail the validation.
+    Valid filenames:
+    - "p1234567.nc"
+    - "p7654321.nc"
+    Invalid filenames:
+    - "p0010000.nc"
+    - "p0000001.nc"
+    - "p000000.nc"
+    - "p12345678.nc"
+    - "p123456.nc"
+    - "p1234567.txt"
+    - "1234567.nc"
+    - "pabcdefg.nc"
+    The test asserts that the _validate_filename function returns True for valid
+    filenames and False for invalid filenames, providing an appropriate error
+    message if the assertion fails.
+    """
+    
+    valid_filenames = [
+        "p1234567.nc",
+        "p7654321.nc",
+        "p0330001_20100903.nc"
+    ]
+    invalid_filenames = [
+        "p0010000.nc",
+        "p0000001.nc",
+        "p000000.nc",
+        "p12345678.nc",
+        "p123456.nc",
+        "p1234567.txt",
+        "1234567.nc",
+        "pabcdefg.nc",
+        "p0420100_20100903T101010.nc"
+    ]
+
+    for filename in valid_filenames:
+        assert readers._validate_filename(filename) is True, f"Expected True for {filename}"
+
+    for filename in invalid_filenames:
+        assert readers._validate_filename(filename) is False, f"Expected False for {filename}"
+
+
+def test_filter_files_by_profile():
+    """
+    Test the filter_files_by_profile function from the readers module.
+    This test checks the filtering of filenames based on the start_profile and
+    end_profile parameters. It uses a list of filenames to filter and the expected
+    result after filtering. The test asserts that the filter_files_by_profile
+    function returns the correct list of filtered filenames, providing an appropriate
+    error message if the assertion fails.
+    """
+    
+    file_list = [
+        "p7654321.nc",
+        "p0010000.nc",
+        "p0000001.nc",
+        "p000000.nc",
+        "p0010001.nc",
+        "p0010002.nc",
+        "p0010003.nc",
+        "p0010004.nc",
+        "p0010005.nc", 
+        "p0010006.nc",
+        "p0010007.nc",
+        "p0010008.nc",
+        "p0010009.nc",
+    ]
+    start_profile = 5
+    end_profile = 20
+    expected_result = ["p0010005.nc", "p0010006.nc", "p0010007.nc", "p0010008.nc", "p0010009.nc"]
+
+    assert readers.filter_files_by_profile(file_list, start_profile, end_profile) == expected_result, "Unexpected result for filter_files_by_profile"
+
+def test_load_basestation_files():
+    """
+    Test the load_basestation_files function from the readers module.
+    This test checks the loading of datasets from either an online source or a local
+    directory, optionally filtering by profile range. It uses a sample dataset and
+    the expected result after loading the dataset. The test asserts that the load_basestation_files
+    function returns the correct dataset, providing an appropriate error message if the
+    assertion fails.
+    """
+    source = "https://www.ncei.noaa.gov/data/oceans/glider/seaglider/uw/033/20100903/"
+    start_profile = 5
+    end_profile = 10
+    datasets = readers.load_basestation_files(source, start_profile, end_profile)
+    assert len(datasets) == 6, "Unexpected number of datasets loaded"
+    assert datasets[-1].dive_number == 10, "Unexpected profile number for last dataset"
+    assert datasets[0].latitude.values.mean() > 18 and datasets[0].latitude.values.mean() < 19, "Unexpected latitude range for first dataset"
+
+def test_load_first_basestation_file():
+    """
+    Test the load_first_basestation_file function from the readers module.
+    This test checks the loading of the first dataset from either an online source
+    or a local directory. It uses a sample dataset and the expected result after
+    loading the dataset. The test asserts that the load_first_basestation_file
+    function returns the correct dataset, providing an appropriate error message
+    if the assertion fails.
+    """
+    source = "https://www.ncei.noaa.gov/data/oceans/glider/seaglider/uw/033/20100903/"
+    dataset = readers.load_first_basestation_file(source)
+    assert dataset.dive_number == 1, "Unexpected profile number for first dataset"
+    assert dataset.latitude.values.mean() > 18.5 and dataset.latitude.values.mean() < 18.6, "Unexpected latitude range for first dataset"
+    assert len(dataset.longitude) == 130, "Unexpected number of longitude values for first dataset"


### PR DESCRIPTION
Added functions to test readers:
- test_demo_datasets
- test_validate_filename: allows for p0420001.nc or p0420001_20251231.nc
- test_filter_files_by_profile: Verifies that the start_profile file and end_profile file are included in the list
- test_load_basestation_files: Checks (for a small seaglider dataset) that files are loaded
- test_load_first_basestation_file: Only added this test because otherwise renaming isn't captured


Updated `run_dataset.ipynb` to give an example of running a full dataset. 

However, I'd like to abstract this more, so that it could be run e.g., as `convertOG input_directory output_directory`