### PR TITLE
[FEAT] Add dive number as a var

### DIFF
--- a/config/OG1_var_names.yaml
+++ b/config/OG1_var_names.yaml
@@ -29,6 +29,7 @@ salinity: PSAL
 #conservative_temperature: CT
 ctd_density: DENSITY
 profile_index: PROFILE_NUMBER
+divenum: DIVE_NUM
 platform: PLATFORM_MODEL
 source: PLATFORM_SERIAL_NUMBER
 vert_speed: GLIDER_VERT_VELO_MODEL


### PR DESCRIPTION
I am not sure this has been decided as an official OG1 var but Callum is using it and we need it if we want to run a suggestion Callum has for the glider track map